### PR TITLE
refactor(events): rename ABC to Base*, and keep a single EventHandler

### DIFF
--- a/product/stream_processor/domain_logic/product_notification.py
+++ b/product/stream_processor/domain_logic/product_notification.py
@@ -1,7 +1,7 @@
 import os
 
 from product.models.products.product import ProductChangeNotification
-from product.stream_processor.integrations.events.event_handler import ProductChangeNotificationHandler
+from product.stream_processor.integrations.events.event_handler import EventHandler
 from product.stream_processor.integrations.events.models.output import EventReceipt
 from product.stream_processor.integrations.events.providers.eventbridge import EventBridge
 
@@ -10,15 +10,15 @@ EVENT_BUS = os.environ.get('EVENT_BUS', '')
 EVENT_SOURCE = 'myorg.product.product_notification'
 
 
-def notify_product_updates(update: list[ProductChangeNotification], event_handler: ProductChangeNotificationHandler | None = None) -> EventReceipt:
+def notify_product_updates(update: list[ProductChangeNotification], event_handler: EventHandler | None = None) -> EventReceipt:
     """Notify product change notifications using default or provided event handler.
 
     Parameters
     ----------
     update : list[ProductChangeNotification]
         List of product change notifications to notify.
-    event_handler : ProductChangeNotificationHandler | None, optional
-        Event handler to use for notification, by default ProductChangeNotificationHandler
+    event_handler : EventHandler | None, optional
+        Event handler to use for notification, by default EventHandler
 
     Environment variables
     ---------------------
@@ -40,7 +40,7 @@ def notify_product_updates(update: list[ProductChangeNotification], event_handle
 
     # Events
 
-    * `ProductChangeNotificationHandler` uses `EventBridge` provider to convert and publish `ProductChangeNotification` models into events.
+    * `EventHandler` uses `EventBridge` provider to convert and publish `ProductChangeNotification` models into events.
 
     Returns
     -------
@@ -48,6 +48,6 @@ def notify_product_updates(update: list[ProductChangeNotification], event_handle
         Receipts for unsuccessfully and successfully published events.
     """
     if event_handler is None:
-        event_handler = ProductChangeNotificationHandler(provider=EventBridge(EVENT_BUS), event_source=EVENT_SOURCE)
+        event_handler = EventHandler(provider=EventBridge(EVENT_BUS), event_source=EVENT_SOURCE)
 
     return event_handler.emit(payload=update)

--- a/product/stream_processor/handlers/process_stream.py
+++ b/product/stream_processor/handlers/process_stream.py
@@ -6,7 +6,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from product.models.products.product import ProductChangeNotification
 from product.stream_processor.domain_logic.product_notification import notify_product_updates
-from product.stream_processor.integrations.events.event_handler import ProductChangeNotificationHandler
+from product.stream_processor.integrations.events.event_handler import EventHandler
 from product.stream_processor.integrations.events.models.output import EventReceipt
 
 logger = Logger()
@@ -16,7 +16,7 @@ logger = Logger()
 def process_stream(
     event: dict[str, Any],
     context: LambdaContext,
-    event_handler: ProductChangeNotificationHandler | None = None,
+    event_handler: EventHandler | None = None,
 ) -> EventReceipt:
     """Process batch of Amazon DynamoDB Stream containing product changes.
 
@@ -33,8 +33,8 @@ def process_stream(
         It is used to enrich our structured logging via Powertools for AWS Lambda.
 
         See [sample](https://docs.aws.amazon.com/lambda/latest/dg/python-context.html)
-    event_handler : ProductChangeNotificationHandler | None, optional
-        Event Handler to use to notify product changes, by default `ProductChangeNotificationHandler`
+    event_handler : EventHandler | None, optional
+        Event Handler to use to notify product changes, by default `EventHandler`
 
     Integrations
     ------------

--- a/product/stream_processor/integrations/events/base.py
+++ b/product/stream_processor/integrations/events/base.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-from product.stream_processor.integrations.events.functions import build_events_from_models
 from product.stream_processor.integrations.events.models.input import Event
 from product.stream_processor.integrations.events.models.output import EventReceipt
 
@@ -50,12 +49,12 @@ class BaseEventHandler(ABC, Generic[T]):
 
     @abstractmethod
     def emit(self, payload: list[T], metadata: dict[str, Any] | None = None, correlation_id='') -> EventReceipt:
-        """Emits product change notifications using registered provider, along with additional metadata or specific correlation ID.
+        """Emits events using registered provider, along with additional metadata or specific correlation ID.
 
         Parameters
         ----------
         payload : list[T]
-            List of product change notifications models to be sent.
+            List of models to convert and publish as an Event.
         metadata : dict[str, Any] | None, optional
             Additional metadata to be injected into the event before sending, by default None
         correlation_id : str, optional
@@ -66,7 +65,4 @@ class BaseEventHandler(ABC, Generic[T]):
         EventReceipt
             Receipts for unsuccessfully and successfully published events.
         """
-        event_payload = build_events_from_models(
-            models=payload, metadata=metadata, correlation_id=correlation_id,
-            event_source=self.event_source)  # type: ignore[type-var] # T will be defined by its implementation; see ProductChangeNotificationHandler
-        return self.provider.send(payload=event_payload)
+        ...

--- a/product/stream_processor/integrations/events/base.py
+++ b/product/stream_processor/integrations/events/base.py
@@ -33,7 +33,7 @@ class BaseEventProvider(ABC):
         ...
 
 
-class EventHandler(ABC, Generic[T]):
+class BaseEventHandler(ABC, Generic[T]):
 
     def __init__(self, provider: BaseEventProvider, event_source: str) -> None:
         """ABC to handle event manipulation from a model, and publishing through a provider.

--- a/product/stream_processor/integrations/events/base.py
+++ b/product/stream_processor/integrations/events/base.py
@@ -8,7 +8,7 @@ from product.stream_processor.integrations.events.models.output import EventRece
 T = TypeVar('T')
 
 
-class EventProvider(ABC):
+class BaseEventProvider(ABC):
     """ABC for an Event Provider that send events to a destination."""
 
     @abstractmethod
@@ -35,12 +35,12 @@ class EventProvider(ABC):
 
 class EventHandler(ABC, Generic[T]):
 
-    def __init__(self, provider: EventProvider, event_source: str) -> None:
+    def __init__(self, provider: BaseEventProvider, event_source: str) -> None:
         """ABC to handle event manipulation from a model, and publishing through a provider.
 
         Parameters
         ----------
-        provider : EventProvider
+        provider : BaseEventProvider
             Event Provider to publish events through.
         event_source : str
             Event source name, e.g., 'myorg.service.feature'

--- a/product/stream_processor/integrations/events/event_handler.py
+++ b/product/stream_processor/integrations/events/event_handler.py
@@ -1,18 +1,18 @@
 from typing import Any
 
 from product.models.products.product import ProductChangeNotification
-from product.stream_processor.integrations.events.base import EventHandler, EventProvider
+from product.stream_processor.integrations.events.base import EventHandler, BaseEventProvider
 from product.stream_processor.integrations.events.models.output import EventReceipt
 
 
 class ProductChangeNotificationHandler(EventHandler):
 
-    def __init__(self, provider: EventProvider, event_source: str) -> None:
+    def __init__(self, provider: BaseEventProvider, event_source: str) -> None:
         """Event Handler for ProductChangeNotification.
 
         Parameters
         ----------
-        provider : EventProvider
+        provider : BaseEventProvider
             An event provider to send events to.
         event_source : str
             Event source to inject in event metadata, following 'myorg.service_name.feature_name'

--- a/product/stream_processor/integrations/events/event_handler.py
+++ b/product/stream_processor/integrations/events/event_handler.py
@@ -1,11 +1,11 @@
 from typing import Any
 
 from product.models.products.product import ProductChangeNotification
-from product.stream_processor.integrations.events.base import EventHandler, BaseEventProvider
+from product.stream_processor.integrations.events.base import BaseEventHandler, BaseEventProvider
 from product.stream_processor.integrations.events.models.output import EventReceipt
 
 
-class ProductChangeNotificationHandler(EventHandler):
+class ProductChangeNotificationHandler(BaseEventHandler):
 
     def __init__(self, provider: BaseEventProvider, event_source: str) -> None:
         """Event Handler for ProductChangeNotification.

--- a/product/stream_processor/integrations/events/event_handler.py
+++ b/product/stream_processor/integrations/events/event_handler.py
@@ -1,14 +1,23 @@
+import re
 from typing import Any
+from uuid import uuid4
 
-from product.models.products.product import ProductChangeNotification
 from product.stream_processor.integrations.events.base import BaseEventHandler, BaseEventProvider
+from product.stream_processor.integrations.events.constants import DEFAULT_EVENT_VERSION
+from product.stream_processor.integrations.events.models.input import AnyModel, Event, EventMetadata
 from product.stream_processor.integrations.events.models.output import EventReceipt
 
+_exclude_underscores = r'(?!^)(?<!_)'  # _ProductNotification
+_pascal_case = r'[A-Z][a-z]+'  # ProductNotification
+_followed_by_lower_case_or_digit = r'(?<=[a-z0-9])[A-Z])'  # V1ProductNotification
+_or = r'|'
+_pascal_to_snake_pattern = re.compile(rf'({_exclude_underscores}{_pascal_case}{_or}{_followed_by_lower_case_or_digit}')
 
-class ProductChangeNotificationHandler(BaseEventHandler):
+
+class EventHandler(BaseEventHandler[AnyModel]):
 
     def __init__(self, provider: BaseEventProvider, event_source: str) -> None:
-        """Event Handler for ProductChangeNotification.
+        """Event Handler for emitting events with a given provider.
 
         Parameters
         ----------
@@ -19,12 +28,12 @@ class ProductChangeNotificationHandler(BaseEventHandler):
         """
         super().__init__(provider=provider, event_source=event_source)
 
-    def emit(self, payload: list[ProductChangeNotification], metadata: dict[str, Any] | None = None, correlation_id='') -> EventReceipt:
-        """Emits product change notifications using registered provider, along with additional metadata or specific correlation ID.
+    def emit(self, payload: list[AnyModel], metadata: dict[str, Any] | None = None, correlation_id='') -> EventReceipt:
+        """Converts and emits a list of models into standard events with extra metadata and correlation ID.
 
         Parameters
         ----------
-        payload : list[ProductChangeNotification]
+        payload : list[AnyModel]
             List of product change notifications models to be sent.
         metadata : dict[str, Any] | None, optional
             Additional metadata to be injected into the event before sending, by default None
@@ -36,4 +45,103 @@ class ProductChangeNotificationHandler(BaseEventHandler):
         EventReceipt
             Receipts for unsuccessfully and successfully published events.
         """
-        return super().emit(payload, metadata, correlation_id)
+        event_payload = EventHandler.build_events_from_models(models=payload, metadata=metadata, correlation_id=correlation_id,
+                                                              event_source=self.event_source)
+        return self.provider.send(payload=event_payload)
+
+    @staticmethod
+    def extract_event_name_from_model(model: AnyModel) -> str:
+        """Derives a standard event name from the name of the model.
+
+        It uses snake_case in uppercase letters, e.g., `ProductNotification` -> `PRODUCT_NOTIFICATION`.
+
+        It also keeps numbers and acronyms that are typically abbreviation for something intact, e.g.: "ProductHTTP" -> "PRODUCT_HTTP"
+
+        Parameters
+        ----------
+        model : AnyModel
+            BaseModel to derive name from.
+
+        # Examples
+
+        Building event name from a given model
+
+        ```python
+        from pydantic import BaseModel
+        from product.stream_processor.integrations.events.event_handler import EventHandler
+
+        class SampleNotification(BaseModel):
+            message: str
+
+        notification = SampleNotification(message='testing')
+        event_name = EventHandler.convert_model_to_event_name(notification)
+
+        assert event_name == "SAMPLE_NOTIFICATION"
+        ```
+
+        Returns
+        -------
+        str
+            Standard event name in snake_case upper letters.
+        """
+        model_name: str = model.__class__.__name__
+        return _pascal_to_snake_pattern.sub(r'_\1', model_name).upper()
+
+    @staticmethod
+    def build_events_from_models(models: list[AnyModel], event_source: str, metadata: dict[str, Any] | None = None,
+                                 correlation_id: str = '') -> list[Event]:
+        """Converts a Pydantic model into a standard event.
+
+        Parameters
+        ----------
+        models : list[AnyModel]
+            List of Pydantic models to convert into events.
+        event_source : str
+            Event source name to inject into event metadata.
+        metadata : dict[str, Any] | None, optional
+            Additional metadata to inject, by default None
+        correlation_id : str, optional
+            Correlation ID to use in event metadata. If not provided, we generate one using UUID4.
+
+
+        # Examples
+
+        Building standard events from a list of models
+
+        ```python
+        from pydantic import BaseModel
+        from product.stream_processor.integrations.events.event_handler import EventHandler
+
+        class SampleNotification(BaseModel):
+            message: str
+
+        notification = SampleNotification(message='testing')
+        event_source = "myorg.product.product_change_stream"
+        events = EventHandler.build_events_from_models(models=[notification], event_source=event_source)
+
+        event = events[0]
+
+        assert event.event_source == event_source
+        assert event.data == notification
+        ```
+
+        Returns
+        -------
+        list[Event]
+            List of events created from model ready to be emitted.
+        """
+        metadata = metadata or {}
+        correlation_id = correlation_id or f'{uuid4()}'
+
+        events: list[Event] = []
+
+        for model in models:
+            event_name = EventHandler.extract_event_name_from_model(model=model)
+            event_version = getattr(model, '__version__', DEFAULT_EVENT_VERSION)  # defaults to v1
+
+            events.append(
+                Event(
+                    data=model, metadata=EventMetadata(event_name=event_name, event_source=event_source, event_version=event_version,
+                                                       correlation_id=correlation_id, **metadata)))
+
+        return events

--- a/product/stream_processor/integrations/events/functions.py
+++ b/product/stream_processor/integrations/events/functions.py
@@ -1,92 +1,9 @@
 """Standalone functions related to events integration. These are reused in more than one location, and tested separately"""
 
-import re
-from typing import Any, Generator, Sequence, TypeVar
-from uuid import uuid4
-
-from product.stream_processor.integrations.events.constants import DEFAULT_EVENT_VERSION
-from product.stream_processor.integrations.events.models.input import AnyModel, Event, EventMetadata
+from typing import Generator, TypeVar
 
 T = TypeVar('T')
 """Generic type for a list of events"""
-
-# full regex: ((?!^)(?<!_)[A-Z][a-z]+|(?<=[a-z0-9])[A-Z])
-_exclude_underscores = r'(?!^)(?<!_)'  # _ProductNotification
-_pascal_case = r'[A-Z][a-z]+'  # ProductNotification
-_followed_by_lower_case_or_digit = r'(?<=[a-z0-9])[A-Z])'  # V1ProductNotification
-_or = r'|'
-_pascal_to_snake_pattern = re.compile(rf'({_exclude_underscores}{_pascal_case}{_or}{_followed_by_lower_case_or_digit}')
-
-
-def convert_model_to_event_name(model_name: str) -> str:
-    """Derives a standard event name from the name of the model.
-
-    It uses snake_case in uppercase letters, e.g., `ProductNotification` -> `PRODUCT_NOTIFICATION`.
-
-    It also keeps numbers and acronyms that are typically abbreviation for something intact, e.g.: "ProductHTTP" -> "PRODUCT_HTTP"
-
-    Parameters
-    ----------
-    model_name : str
-        Name of the model to derive from.
-
-    # Examples
-
-    ```python
-    from pydantic import BaseModel
-
-    class SampleNotification(BaseModel):
-        message: str
-
-    notification = SampleNotification(message='testing')
-    event_name = convert_model_to_event_name(notification.__class__.__name__)
-
-    assert event_name == "SAMPLE_NOTIFICATION"
-    ```
-
-    Returns
-    -------
-    str
-        Standard event name in snake_case upper letters.
-    """
-    return _pascal_to_snake_pattern.sub(r'_\1', model_name).upper()
-
-
-def build_events_from_models(models: Sequence[AnyModel], event_source: str, metadata: dict[str, Any] | None = None,
-                             correlation_id: str = '') -> list[Event]:
-    """Converts a Pydantic model into a standard event.
-
-    Parameters
-    ----------
-    models : Sequence[AnyModel]
-        List of Pydantic models to convert into events.
-    event_source : str
-        Event source name to inject into event metadata.
-    metadata : dict[str, Any] | None, optional
-        Additional metadata to inject, by default None
-    correlation_id : str, optional
-        Correlation ID to use in event metadata. If not provided, we generate one using UUID4.
-
-    Returns
-    -------
-    list[Event]
-        List of events created from model ready to be emitted.
-    """
-    metadata = metadata or {}
-    correlation_id = correlation_id or f'{uuid4()}'
-
-    events: list[Event] = []
-
-    for model in models:
-        event_name = convert_model_to_event_name(model_name=model.__class__.__name__)
-        event_version = getattr(model, '__version__', DEFAULT_EVENT_VERSION)  # defaults to v1
-
-        events.append(
-            Event(
-                data=model, metadata=EventMetadata(event_name=event_name, event_source=event_source, event_version=event_version,
-                                                   correlation_id=correlation_id, **metadata)))
-
-    return events
 
 
 def chunk_from_list(events: list[T], max_items: int) -> Generator[list[T], None, None]:

--- a/product/stream_processor/integrations/events/providers/eventbridge.py
+++ b/product/stream_processor/integrations/events/providers/eventbridge.py
@@ -5,7 +5,7 @@ import boto3
 import botocore.exceptions
 
 from product.constants import XRAY_TRACE_ID_ENV
-from product.stream_processor.integrations.events.base import EventProvider
+from product.stream_processor.integrations.events.base import BaseEventProvider
 from product.stream_processor.integrations.events.constants import EVENTBRIDGE_PROVIDER_MAX_EVENTS_ENTRY
 from product.stream_processor.integrations.events.exceptions import ProductChangeNotificationDeliveryError
 from product.stream_processor.integrations.events.functions import chunk_from_list
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from mypy_boto3_events.type_defs import PutEventsRequestEntryTypeDef, PutEventsResponseTypeDef
 
 
-class EventBridge(EventProvider):
+class EventBridge(BaseEventProvider):
 
     def __init__(self, bus_name: str, client: Optional['EventBridgeClient'] = None):
         """Amazon EventBridge provider using PutEvents API.

--- a/tests/unit/stream_processor/conftest.py
+++ b/tests/unit/stream_processor/conftest.py
@@ -3,7 +3,7 @@ from typing import Any, Generator, Sequence, TypeVar
 from pytest_socket import disable_socket
 
 from product.models.products.product import ProductChangeNotification
-from product.stream_processor.integrations.events.base import EventProvider
+from product.stream_processor.integrations.events.base import BaseEventProvider
 from product.stream_processor.integrations.events.event_handler import ProductChangeNotificationHandler
 from product.stream_processor.integrations.events.functions import build_events_from_models
 from product.stream_processor.integrations.events.models.input import Event
@@ -24,7 +24,7 @@ Fixture = Generator[T, None, None]
 # -- Simple reference for an EventHandler and EventProvider
 
 
-class FakeProvider(EventProvider):
+class FakeProvider(BaseEventProvider):
 
     def send(self, payload: Sequence[Event]) -> EventReceipt:
         notifications = [EventReceiptSuccess(receipt_id='test') for _ in payload]
@@ -33,7 +33,7 @@ class FakeProvider(EventProvider):
 
 class FakeEventHandler(ProductChangeNotificationHandler):
 
-    def __init__(self, provider: EventProvider = FakeProvider(), event_source: str = 'fake') -> None:
+    def __init__(self, provider: BaseEventProvider = FakeProvider(), event_source: str = 'fake') -> None:
         super().__init__(provider=provider, event_source=event_source)
         self.published_payloads: list[ProductChangeNotification] = []
 

--- a/tests/unit/stream_processor/conftest.py
+++ b/tests/unit/stream_processor/conftest.py
@@ -1,12 +1,10 @@
-from typing import Any, Generator, Sequence, TypeVar
+from typing import Any, Sequence
 
 from pytest_socket import disable_socket
 
-from product.models.products.product import ProductChangeNotification
-from product.stream_processor.integrations.events.base import BaseEventProvider
-from product.stream_processor.integrations.events.event_handler import ProductChangeNotificationHandler
-from product.stream_processor.integrations.events.functions import build_events_from_models
-from product.stream_processor.integrations.events.models.input import Event
+from product.stream_processor.integrations.events.base import BaseEventHandler, BaseEventProvider
+from product.stream_processor.integrations.events.event_handler import EventHandler
+from product.stream_processor.integrations.events.models.input import AnyModel, Event
 from product.stream_processor.integrations.events.models.output import EventReceipt, EventReceiptSuccess
 
 
@@ -14,9 +12,6 @@ def pytest_runtest_setup():
     """Disable Unix and TCP sockets for Data masking tests"""
     disable_socket()
 
-
-T = TypeVar('T')
-Fixture = Generator[T, None, None]
 
 # Fakes are in-memory implementations of our interface, serving the following purposes:
 # -- Remove the need for mocks that need to be aware of scope and return types
@@ -31,15 +26,15 @@ class FakeProvider(BaseEventProvider):
         return EventReceipt(success=notifications)
 
 
-class FakeEventHandler(ProductChangeNotificationHandler):
+class FakeEventHandler(BaseEventHandler[AnyModel]):
 
     def __init__(self, provider: BaseEventProvider = FakeProvider(), event_source: str = 'fake') -> None:
         super().__init__(provider=provider, event_source=event_source)
-        self.published_payloads: list[ProductChangeNotification] = []
+        self.published_payloads: list[AnyModel] = []
 
-    def emit(self, payload: list[ProductChangeNotification], metadata: dict[str, Any] | None = None, correlation_id='') -> EventReceipt:
+    def emit(self, payload: list[AnyModel], metadata: dict[str, Any] | None = None, correlation_id='') -> EventReceipt:
         metadata = metadata or {}
-        event_payload = build_events_from_models(models=payload, metadata=metadata, correlation_id=correlation_id, event_source='fake')
+        event_payload = EventHandler.build_events_from_models(models=payload, metadata=metadata, correlation_id=correlation_id, event_source='fake')
         receipt = self.provider.send(payload=event_payload)
 
         self.published_payloads.extend(payload)
@@ -48,5 +43,5 @@ class FakeEventHandler(ProductChangeNotificationHandler):
     def __len__(self):
         return len(self.published_payloads)
 
-    def __contains__(self, item: ProductChangeNotification):
+    def __contains__(self, item: AnyModel):
         return item in self.published_payloads

--- a/tests/unit/stream_processor/test_eventbridge_provider.py
+++ b/tests/unit/stream_processor/test_eventbridge_provider.py
@@ -7,8 +7,8 @@ from pydantic import BaseModel
 
 from product.constants import XRAY_TRACE_ID_ENV
 from product.stream_processor.integrations.events.constants import EVENTBRIDGE_PROVIDER_MAX_EVENTS_ENTRY
+from product.stream_processor.integrations.events.event_handler import EventHandler
 from product.stream_processor.integrations.events.exceptions import ProductChangeNotificationDeliveryError
-from product.stream_processor.integrations.events.functions import build_events_from_models
 from product.stream_processor.integrations.events.providers.eventbridge import EventBridge
 
 
@@ -20,7 +20,7 @@ def test_eventbridge_build_put_events_from_event_payload():
         __version__ = 'V1'
 
     notification = SampleNotification(message='test')
-    events = build_events_from_models(models=[notification], event_source='test')
+    events = EventHandler.build_events_from_models(models=[notification], event_source='test')
 
     # WHEN EventBridge provider builds a PutEvents request
     event_provider = EventBridge(bus_name='test_bus')
@@ -48,7 +48,7 @@ def test_eventbridge_build_put_events_from_event_payload_include_trace_header(mo
 
     event_bus_name = 'sample_bus'
     notification = SampleNotification(message='test')
-    events = build_events_from_models(models=[notification], event_source='test')
+    events = EventHandler.build_events_from_models(models=[notification], event_source='test')
     event_provider = EventBridge(bus_name=event_bus_name)
 
     # WHEN EventBridge provider builds a PutEvents request
@@ -67,7 +67,7 @@ def test_eventbridge_build_put_events_respect_max_entries_limit():
     number_of_events = 20
 
     notifications = [SampleNotification(message='test') for _ in range(number_of_events)]
-    events = build_events_from_models(models=notifications, event_source='test')
+    events = EventHandler.build_events_from_models(models=notifications, event_source='test')
 
     # WHEN EventBridge provider builds a PutEvents request
     requests = EventBridge(bus_name='test_bus').build_put_events_requests(payload=events)
@@ -90,7 +90,7 @@ def test_eventbridge_put_events_with_stubber():
     event_source = 'test'
 
     notification = SampleNotification(message='testing')
-    events = build_events_from_models(models=[notification], event_source=event_source)
+    events = EventHandler.build_events_from_models(models=[notification], event_source=event_source)
     event = events[0]
 
     put_events_request = {
@@ -134,7 +134,7 @@ def test_eventbridge_put_events_with_stubber_partial_failure():
     event_source = 'test'
 
     notification = SampleNotification(message='testing')
-    events = build_events_from_models(models=[notification], event_source=event_source)
+    events = EventHandler.build_events_from_models(models=[notification], event_source=event_source)
     event = events[0]
 
     expected_failure_count = 1
@@ -188,7 +188,7 @@ def test_eventbridge_put_events_with_stubber_service_failure():
     event_source = 'test'
 
     notification = SampleNotification(message='testing')
-    events = build_events_from_models(models=[notification], event_source=event_source)
+    events = EventHandler.build_events_from_models(models=[notification], event_source=event_source)
 
     # WHEN EventBridge receives a stubbed client with at least one FailedEntryCount
     client = boto3.client('events')

--- a/tests/unit/stream_processor/test_events.py
+++ b/tests/unit/stream_processor/test_events.py
@@ -3,7 +3,8 @@ from uuid import uuid4
 from pydantic import BaseModel
 
 from product.stream_processor.integrations.events.constants import DEFAULT_EVENT_VERSION
-from product.stream_processor.integrations.events.functions import build_events_from_models, convert_model_to_event_name
+from product.stream_processor.integrations.events.event_handler import EventHandler
+from product.stream_processor.integrations.events.models.input import Event
 
 
 def test_model_to_standard_event():
@@ -17,14 +18,14 @@ def test_model_to_standard_event():
     event_source = 'test'
 
     # WHEN we convert to an event
-    event = build_events_from_models(models=[notification], event_source=event_source)[0]
+    event = EventHandler.build_events_from_models(models=[notification], event_source=event_source)[0]
 
     # THEN the event should contain our notification in `.data`, all metadata under `.metadata`
     # infer the event version from the model, event name infers model name from PascalCase to SNAKE_CASE_UPPER
     assert event.data == notification
     assert event.metadata.event_source == event_source
     assert event.metadata.event_version == notification.__version__
-    assert event.metadata.event_name == convert_model_to_event_name(notification.__class__.__name__)
+    assert event.metadata.event_name == EventHandler.extract_event_name_from_model(notification)
     assert event.metadata.correlation_id != ''
     assert event.metadata.created_at != ''
 
@@ -41,7 +42,7 @@ def test_model_to_standard_event_with_correlation_id():
     correlation_id = f'{uuid4()}'
 
     # WHEN we convert to an event
-    event = build_events_from_models(models=[notification], event_source=event_source, correlation_id=correlation_id)[0]
+    event = EventHandler.build_events_from_models(models=[notification], event_source=event_source, correlation_id=correlation_id)[0]
 
     # THEN we should have the same correlation ID in the final event
     assert event.metadata.correlation_id == correlation_id
@@ -59,7 +60,7 @@ def test_model_to_standard_event_with_additional_metadata():
     metadata = {'product_id': 'test', 'username': 'lessa'}
 
     # WHEN we convert to an event
-    event = build_events_from_models(models=[notification], event_source=event_source, metadata=metadata)[0]
+    event = EventHandler.build_events_from_models(models=[notification], event_source=event_source, metadata=metadata)[0]
 
     # THEN we should have additional metadata included in the final event
     assert metadata.items() <= event.metadata.model_dump().items()
@@ -74,7 +75,62 @@ def test_model_without_version_to_standard_event():
     event_source = 'test'
 
     # WHEN we convert to an event
-    event = build_events_from_models(models=[notification], event_source=event_source)[0]
+    event = EventHandler.build_events_from_models(models=[notification], event_source=event_source)[0]
 
     # THEN we should add a default v1 version
     assert event.metadata.event_version == DEFAULT_EVENT_VERSION
+
+
+def test_convert_pascal_case_to_snake_case_with_convert_model_to_event_name():
+    # GIVEN a model name in pascal case
+    class ProductNotification(BaseModel):
+        message: str
+
+    notification = ProductNotification(message='testing')
+
+    # WHEN we call convert_model_to_event_name
+    event_name = EventHandler.extract_event_name_from_model(notification)
+
+    # THEN we get the expected event name
+    assert event_name == 'product_notification'.upper()
+
+
+def test_convert_model_to_event_name_with_uppercase():
+    # GIVEN a model name in pascal case
+    class ProductHTTPNotification(BaseModel):
+        message: str
+
+    notification = ProductHTTPNotification(message='testing')
+
+    # WHEN we call convert_model_to_event_name
+    event_name = EventHandler.extract_event_name_from_model(notification)
+
+    # THEN we get the expected event name
+    assert event_name == 'product_http_notification'.upper()
+
+
+def test_convert_model_to_event_name_with_numbers():
+    # GIVEN a model name in pascal case
+    class ProductHTTPNotification123(BaseModel):
+        message: str
+
+    notification = ProductHTTPNotification123(message='testing')
+
+    # WHEN we call convert_model_to_event_name
+    event_name = EventHandler.extract_event_name_from_model(notification)
+
+    # THEN we get the expected event name
+    assert event_name == 'product_http_notification123'.upper()
+
+
+def test_build_events_from_models():
+    # GIVEN any Pydantic model
+    class SampleNotification(BaseModel):
+        message: str
+
+    # WHEN we call build_events_from_models with all required fields
+    notification = SampleNotification(message='Hello World!')
+    event = EventHandler.build_events_from_models(models=[notification], event_source='sample')
+
+    # THEN we get a list of Events
+    assert type(event[0]) is Event

--- a/tests/unit/stream_processor/test_functions.py
+++ b/tests/unit/stream_processor/test_functions.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel
-
-from product.stream_processor.integrations.events.functions import build_events_from_models, chunk_from_list, convert_model_to_event_name
-from product.stream_processor.integrations.events.models.input import Event
+from product.stream_processor.integrations.events.functions import chunk_from_list
 
 
 def test_chunk_from_list_returns_empty_list_when_list_is_empty():
@@ -43,49 +40,3 @@ def test_chunk_from_list_returns_multiple_chunks_when_list_size_is_greater_than_
 
     # THEN we get a chunk of the same size as the list
     assert actual_chunks == expected_chunks
-
-
-def test_convert_pascal_case_to_snake_case_with_convert_model_to_event_name():
-    # GIVEN a model name in pascal case
-    model_name = 'ProductNotification'
-
-    # WHEN we call convert_model_to_event_name
-    event_name = convert_model_to_event_name(model_name)
-
-    # THEN we get the expected event name
-    assert event_name == 'product_notification'.upper()
-
-
-def test_convert_model_to_event_name_with_uppercase():
-    # GIVEN a model name in pascal case
-    model_name = 'ProductHTTPNotification'
-
-    # WHEN we call convert_model_to_event_name
-    event_name = convert_model_to_event_name(model_name)
-
-    # THEN we get the expected event name
-    assert event_name == 'product_http_notification'.upper()
-
-
-def test_convert_model_to_event_name_with_numbers():
-    # GIVEN a model name in pascal case
-    model_name = 'ProductHTTPNotification123'
-
-    # WHEN we call convert_model_to_event_name
-    event_name = convert_model_to_event_name(model_name)
-
-    # THEN we get the expected event name
-    assert event_name == 'product_http_notification123'.upper()
-
-
-def test_build_events_from_models():
-    # GIVEN any Pydantic model
-    class SampleNotification(BaseModel):
-        message: str
-
-    # WHEN we call build_events_from_models with all required fields
-    notification = SampleNotification(message='Hello World!')
-    event = build_events_from_models(models=[notification], event_source='sample')
-
-    # THEN we get a list of Events
-    assert type(event[0]) is Event


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
<!-- Add issue number next to close keyword so it links PR and issue for auto-closure -->
closes #76 

## Summary

> Please provide a summary of what's being changed

Removed `ProductChangeNotificationHandler` and refactored to have a single `EventHandler`, since the code is now generic enough compared to how the skeleton started.

Reduces cognitive load in understanding the code, and move standalone functions under `EventHandler` as a staticmethod for better alignment.

Used generics to accept any Pydantic BaseModel. There's no longer value in keeping a whole boilerplate only to validate whether a specific model was passed.

### User experience

> If applicable, please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows conventional commit semantics

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
